### PR TITLE
Fix cv::Exception

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   machine: amd64
 install:
   - cinst winflexbison
-  - cinst opencv
+  - cinst opencv -Version 3.2.0
   - dir C:\tools\opencv\build\include
   - dir C:\tools\opencv\build\x64\vc14\lib
   - dir C:\tools\opencv\build\x64\vc14\bin

--- a/src/opencv.cpp
+++ b/src/opencv.cpp
@@ -216,7 +216,9 @@ simpleLoop(mrb_state *mrb, mrb_value block, mrb_value self)
     // cvtColor(frame, edges, COLOR_BGR2GRAY);
     // GaussianBlur(edges, edges, Size(7, 7), 1.5, 1.5);
     // Canny(edges, edges, 0, 30, 3);
-    cv::imshow(CAM_WINDOW_NAME, frame);
+    if(!frame.empty()) {
+      cv::imshow(CAM_WINDOW_NAME, frame);
+    }
     int keyCode = cv::waitKey(30);
     if (keyCode == 0x1b) {
       cap.release();


### PR DESCRIPTION
This patch Fix following error:

```txt
OpenCV(3.4.1) Error: Assertion failed (size.width>0 && size.height>0) in imshow, file /tmp/opencv-20180630-96466-n6g9lf/opencv-3.4.1/modules/highgui/src/window.cpp, line 356 libc++abi.dylib: terminating with uncaught exception of type cv::Exception: OpenCV(3.4.1) /tmp/opencv-20180630-96466-n6g9lf/opencv-3.4.1/modules/highgui/src/window.cpp:356: error: (-215) size.width>0 && size.height>0 in function imshow
```