### PR TITLE
Add webcam.each

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -62,6 +62,9 @@ MRuby::Gem::Specification.new('mruby-webcam') do |spec|
       spec.linker.flags_before_libraries << "-framework OpenCL -framework Cocoa -framework QTKit"
       spec.linker.flags_before_libraries << "-framework QuartzCore -framework AppKit"
     end
+  elsif system('pkg-config opencv4')
+    spec.cc.flags << `pkg-config --cflags opencv4`.strip
+    spec.linker.flags_before_libraries << `pkg-config --libs opencv4`.strip
   else
     if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR'] then
       worldLib = "opencv_world320.lib"

--- a/src/mrb_webcam.c
+++ b/src/mrb_webcam.c
@@ -44,20 +44,14 @@ mrb_webcam_init(mrb_state *mrb, mrb_value self)
   DATA_PTR(self) = NULL;
 
   mrb_get_args(mrb, "|o", &device);
-  if (!mrb_nil_p(device)) {
-    data = (mrb_webcam_data *)mrb_malloc(mrb, sizeof(mrb_webcam_data));
-    data->num = 0;
-    data->str = NULL;
-    if (mrb_type(device) == MRB_TT_STRING)
-      data->str = RSTRING_PTR(device);
-    else
-      data->num = mrb_fixnum(device);
-	printf("%s, %d\n", data->str, data->num);
-  } else {
-    data->str = NULL;
-    data->num = 0;
-  }
 
+  data = (mrb_webcam_data *)mrb_malloc(mrb, sizeof(mrb_webcam_data));
+  data->str = NULL;
+  data->num = 0;
+  if (mrb_type(device) == MRB_TT_STRING)
+    data->str = RSTRING_PTR(device);
+  else if (mrb_type(device) == MRB_TT_FIXNUM)
+    data->num = mrb_fixnum(device);
   DATA_PTR(self) = data;
 
   val = mrb_funcall(mrb, self, "init2", 0);

--- a/src/mrb_webcam.c
+++ b/src/mrb_webcam.c
@@ -9,22 +9,20 @@
 #include "mrb_webcam.h"
 #include "mruby.h"
 #include "mruby/data.h"
+#include "mruby/string.h"
 #include "mruby/variable.h"
 #include <string.h>
 
 extern int
 webcam_start(mrb_state *, mrb_value);
 extern int
+webcam_each(mrb_state *, mrb_value);
+extern int
 webcam_snap(mrb_state *, mrb_value, mrb_value);
 extern int
 webcam_close(mrb_state *, mrb_value);
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
-
-typedef struct {
-  char *str;
-  int len;
-} mrb_webcam_data;
 
 static const struct mrb_data_type mrb_webcam_data_type = {
   "mrb_webcam_data", mrb_free,
@@ -34,8 +32,7 @@ static mrb_value
 mrb_webcam_init(mrb_state *mrb, mrb_value self)
 {
   mrb_webcam_data *data;
-  char *str;
-  int len;
+  mrb_value str;
   mrb_value haarcascadePath;
 
   data = (mrb_webcam_data *)DATA_PTR(self);
@@ -45,15 +42,13 @@ mrb_webcam_init(mrb_state *mrb, mrb_value self)
   DATA_TYPE(self) = &mrb_webcam_data_type;
   DATA_PTR(self) = NULL;
 
-  mrb_get_args(mrb, "|s", &str, &len);
+  mrb_get_args(mrb, "|o", &str);
   // mrb_get_args(mrb, "s", &str, &len);
   data = (mrb_webcam_data *)mrb_malloc(mrb, sizeof(mrb_webcam_data));
-  if (len > 0) {
-    data->str = str;
-    data->len = len;
+  if (!mrb_nil_p(str)) {
+    data->str = RSTRING_PTR(str);
   } else {
     data->str = NULL;
-    data->len = 0;
   }
 
   DATA_PTR(self) = data;
@@ -68,7 +63,7 @@ mrb_webcam_hello(mrb_state *mrb, mrb_value self)
 {
   mrb_webcam_data *data = (mrb_webcam_data *)DATA_PTR(self);
 
-  return mrb_str_new(mrb, data->str, data->len);
+  return mrb_str_new_cstr(mrb, data->str);
 }
 
 static mrb_value
@@ -113,6 +108,18 @@ mrb_webcam_start(mrb_state *mrb, mrb_value self)
   return mrb_true_value();
 }
 
+static mrb_value
+mrb_webcam_each(mrb_state *mrb, mrb_value self)
+{
+  int rtn = webcam_each(mrb, self);
+  if (rtn != 0) {
+    return mrb_false_value();
+    // return mrb_str_new_cstr(mrb, "");
+    // captureブロックを呼び出す
+  }
+  return mrb_true_value();
+}
+
 void
 mrb_mruby_webcam_gem_init(mrb_state *mrb)
 {
@@ -124,6 +131,7 @@ mrb_mruby_webcam_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, webcam, "snap", mrb_webcam_snap, MRB_ARGS_NONE());
   mrb_define_method(mrb, webcam, "close", mrb_webcam_close, MRB_ARGS_NONE());
   mrb_define_method(mrb, webcam, "start", mrb_webcam_start, MRB_ARGS_NONE());
+  mrb_define_method(mrb, webcam, "each", mrb_webcam_each, MRB_ARGS_NONE());
   DONE;
 }
 

--- a/src/mrb_webcam.h
+++ b/src/mrb_webcam.h
@@ -9,6 +9,7 @@
 #include "mruby.h"
 
 typedef struct {
+  int num;
   char *str;
 } mrb_webcam_data;
 

--- a/src/mrb_webcam.h
+++ b/src/mrb_webcam.h
@@ -8,6 +8,10 @@
 #define MRB_WEBCAM_H
 #include "mruby.h"
 
+typedef struct {
+  char *str;
+} mrb_webcam_data;
+
 void
 mrb_mruby_webcam_gem_init(mrb_state *mrb);
 

--- a/src/opencv.cpp
+++ b/src/opencv.cpp
@@ -134,7 +134,7 @@ faceLoop(mrb_state *mrb, mrb_value self, mrb_value block, mrb_value faceBlock, m
   }
   cv::VideoCapture cap;
   mrb_webcam_data *data = (mrb_webcam_data*) DATA_PTR(self);
-  if (data != NULL && data->str != NULL)
+  if (data->str != NULL)
     cap = cv::VideoCapture(data->str);
   else
     cap = cv::VideoCapture(data->num);
@@ -226,7 +226,7 @@ simpleLoop(mrb_state *mrb, mrb_value block, mrb_value self)
   cv::VideoCapture cap;
 
   mrb_webcam_data *data = (mrb_webcam_data*) DATA_PTR(self);
-  if (data != NULL && data->str != NULL)
+  if (data->str != NULL)
     cap = cv::VideoCapture(data->str);
   else
     cap = cv::VideoCapture(data->num);
@@ -295,7 +295,7 @@ webcam_each(mrb_state *mrb, mrb_value self)
   cv::VideoCapture cap;
 
   mrb_webcam_data *data = (mrb_webcam_data*) DATA_PTR(self);
-  if (data != NULL && data->str != NULL)
+  if (data->str != NULL)
     cap = cv::VideoCapture(data->str);
   else
     cap = cv::VideoCapture(data->num);


### PR DESCRIPTION
Hi, currently I'm playing with [mruby-tflite](https://github.com/mattn/mruby-tflite) and I use mruby-webcam to detect images on webcam. But mruby-webcam require typing something keys for call handeler. So I added webcam.each.

* Added support pkg-config (with opencv4)
* Add webcam.each method
* Add number argument for Webcam.new (number is camera-id, string is video file or device path)
* Support opencv4